### PR TITLE
openUI5 $metadata request problem

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -240,6 +240,7 @@ export class ODataServer extends Transform{
             if (req.headers.accept &&
                 req.headers.accept.indexOf("application/json") < 0 &&
                 req.headers.accept.indexOf("text/html") < 0 &&
+                req.headers.accept.indexOf("*/*") < 0 &&
                 req.headers.accept.indexOf("xml") < 0){
                 next(new UnsupportedMediaTypeError());
             }else next();


### PR DESCRIPTION
Hello,
openUI5 framework sends Accept: \*/\* when requests $metadata. that's why error 415 occurs. 

> GET /$metadata HTTP/1.1
> Host: localhost:3000
> Connection: keep-alive
> Pragma: no-cache
> Cache-Control: no-cache
> Accept: \*/\*

BR,
Denis