### PR TITLE
A simple change that speeds up queries with $select

### DIFF
--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -18,6 +18,12 @@ const getODataRoot = function(context){
     return (context.protocol || "http") + "://" + (context.host || "localhost") + (context.base || "");
 }
 
+const arrayIntersect = function(a1, a2) {
+    return a1.filter(function(i) {
+        return a2.indexOf(i) !== -1;
+    });
+}
+
 const createODataContext = function(context, entitySets, server:typeof ODataServer, resourcePath, processor){
     let odataContextBase = getODataRoot(context) + "/$metadata#";
     let odataContext = "";
@@ -1181,9 +1187,16 @@ export class ODataProcessor extends Transform{
         let entityType = function(){};
         util.inherits(entityType, elementType);
         result = Object.assign(new entityType(), result);
-        if (props.length > 0){
+
+        let resultKeys = Object.keys(result);
+        let propsToUse = props;
+        if (props.length > resultKeys.length) {
+            propsToUse = arrayIntersect(props, resultKeys);
+        }
+
+        if (propsToUse.length > 0){
             let metadata = {};
-            await Promise.all(props.map(prop => (async prop => {
+            await Promise.all(propsToUse.map(prop => (async prop => {
                 let type:any = Edm.getType(elementType, prop);
                 let itemType;
                 if (typeof type == "function"){


### PR DESCRIPTION
Especially if you have a large model it doesn’t make sense to go through every property when the person doing the query is only getting a small a few of those properties in their query. 

This speeds things up dramatically.

The implementation is simple. I take the incoming set of data (from the db query) and take the number of fields there against our total number of fields. If it's less then we know the request must have had a select to reduce the result set (or they model fields that don't actually exist). 

Then to ensure we are not returning fields that aren't actually in the model and do an intersection of the two arrays. 